### PR TITLE
Fix "time" to produce collect Unix time

### DIFF
--- a/lib/fluent/plugin/node_exporter/time_collector.rb
+++ b/lib/fluent/plugin/node_exporter/time_collector.rb
@@ -35,7 +35,7 @@ module Fluent
 
         def time_update
           current_time = Fluent::EventTime.now
-          value = current_time.to_i / 1e9
+          value = current_time.to_i
           @gauge.set(value)
         end
 

--- a/test/plugin/test_time_collector.rb
+++ b/test/plugin/test_time_collector.rb
@@ -9,7 +9,7 @@ class TimeColectorTest < Test::Unit::TestCase
       stub(Fluent::EventTime).now { Fluent::EventTime.new(1e9) }
       collector.run
       time_seconds = collector.cmetrics[:time_seconds]
-      assert_equal(1.0, time_seconds.val)
+      assert_equal(1_000_000_000, time_seconds.val)
     end
   end
 end


### PR DESCRIPTION
Currently `time` collector produces a record like this:

    [{"name":"node_time_seconds","value":1.643789173,
      "desc":"System time in seconds since epoch (1970).",
      "ts":1643789173610783251}]

This is very bogus, because it essentially says that the current
system time is `1970-01-01 00:00:01.643789173`. Fix it.

Signed-off-by: Fujimoto Seiji <fujimoto@ceptord.net>