### PR TITLE
 Update ruby-version, add Ruby 3.4 for CI

### DIFF
--- a/.github/workflows/linux-test.yaml
+++ b/.github/workflows/linux-test.yaml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: ['3.3', '3.2', '3.1', '3.0', '2.7']
+        ruby-version: ['3.4', '3.3', '3.2', '3.1']
         os: [ubuntu-latest]
         experimental: [false]
         include:

--- a/.github/workflows/linux-test.yaml
+++ b/.github/workflows/linux-test.yaml
@@ -31,8 +31,7 @@ jobs:
         run: |
           sudo apt update
           sudo apt -V install libcap-ng-dev
-          gem install bundler -v 2.2.27
-          bundle _2.2.27_ install
+          bundle install
       - name: setup linux capability (cap_dac_read_search=+eip)
         run: sudo setcap cap_dac_read_search=+eip $(command -v ruby)
         if: ${{ matrix.capability }}

--- a/fluent-plugin-node-exporter-metrics.gemspec
+++ b/fluent-plugin-node-exporter-metrics.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "cmetrics", "~> 0.3.3"
   spec.add_runtime_dependency "capng_c", "~> 0.2.2"
 
-  spec.add_development_dependency "bundler", "~> 2.2.0"
+  spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake", "~> 13.0.6"
   spec.add_development_dependency "test-unit", "~> 3.4.4"
   spec.add_development_dependency "test-unit-rr", "~> 1.0.5"

--- a/fluent-plugin-node-exporter-metrics.gemspec
+++ b/fluent-plugin-node-exporter-metrics.gemspec
@@ -23,6 +23,9 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "cmetrics", "~> 0.3.3"
   spec.add_runtime_dependency "capng_c", "~> 0.2.2"
 
+  # gems that aren't default gems as of Ruby 3.5
+  spec.add_runtime_dependency "ostruct", "~> 0.6"
+
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake", "~> 13.0.6"
   spec.add_development_dependency "test-unit", "~> 3.4.4"


### PR DESCRIPTION
Update ruby-version, add Ruby 3.4 for CI

EOL: 2.7,3.0

See https://www.ruby-lang.org/en/downloads/branches/
